### PR TITLE
chore: add GHCR docker image publishing to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   release:
@@ -26,6 +27,19 @@ jobs:
         with:
           path: target
           key: target
+
+      - name: QEMU Setup
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+
+      - name: Docker Buildx Setup
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run release task
         run: mise run release

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,10 +2,6 @@ version: 2
 
 project_name: ecs-meta2env-rs
 
-before:
-  hooks:
-    - rustup default stable
-
 builds:
   - id: ecs-meta2env-rs
     builder: rust
@@ -24,3 +20,7 @@ archives:
 
 checksum:
   name_template: checksums.txt
+
+dockers_v2:
+  - images:
+      - ghcr.io/hrko/ecs-meta2env-rs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+
+ARG TARGETPLATFORM
+COPY $TARGETPLATFORM/ecs-meta2env-rs /ecs-meta2env-rs

--- a/README.md
+++ b/README.md
@@ -14,16 +14,15 @@ You can download the latest release from the [releases page](https://github.com/
 Below is an example of how to use `ecs-meta2env-rs` in a Dockerfile:
 
 ```Dockerfile
-FROM debian:bookworm-slim AS ecs-meta2env-rs-downloader
-RUN apt-get update && apt-get install -y curl
-RUN if [ "$(uname -m)" = "x86_64" ]; then ARCH="amd64"; else ARCH="arm64"; fi && \
-    curl -L -o /meta2env https://github.com/hrko/ecs-meta2env-rs/releases/download/v1.0.0/ecs-meta2env-rs-$ARCH && \
-    chmod +x /meta2env
+FROM ghcr.io/hrko/ecs-meta2env-rs:latest AS ecs-meta2env-rs
 
 FROM <original-image>
-COPY --from=ecs-meta2env-rs-downloader /meta2env /meta2env
+COPY --from=ecs-meta2env-rs /ecs-meta2env-rs /meta2env
 ENTRYPOINT ["/meta2env", "<original-entrypoint...>"]
 ```
+
+> [!NOTE]
+> For production workloads, prefer pinning the source image by digest (for example, `ghcr.io/hrko/ecs-meta2env-rs@sha256:<digest>`) instead of using a mutable tag like `:latest`.
 
 ## Environment Variables
 

--- a/mise.toml
+++ b/mise.toml
@@ -15,6 +15,9 @@ zig = "0.13.0"
 [tasks.build]
 run = "goreleaser build --snapshot --clean"
 
+[tasks.snapshot]
+run = "goreleaser release --snapshot --clean --skip=publish"
+
 [tasks.release]
 run = "goreleaser release --clean"
 


### PR DESCRIPTION
## Summary
- add `Dockerfile` for packaging `ecs-meta2env-rs` binary into a minimal container image
- update release workflow to set up QEMU/Buildx and login to GHCR
- grant `packages: write` permission for publishing container images
- enable `dockers_v2` in `.goreleaser.yaml` to publish `ghcr.io/hrko/ecs-meta2env-rs`
- add `mise run snapshot` task for local snapshot validation

## Notes
- built from `scratch` base image
- release continues to publish existing binaries/checksums, with container image publishing added
