### PR TITLE
Add latest tag to Docker release image

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,3 +24,6 @@ checksum:
 dockers_v2:
   - images:
       - ghcr.io/hrko/ecs-meta2env-rs
+    tags:
+      - "v{{ .Version }}"
+      - latest


### PR DESCRIPTION
## Summary
- Add explicit Docker image tags for GoReleaser dockers_v2
- Preserve the release tag with {{ .Tag }} and also publish latest

## Verification
- goreleaser check